### PR TITLE
Filebeat enable http api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development do
 end
 
 group :system_tests do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
+    gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.37')
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem 'beaker-puppet_install_helper'
   gem 'beaker-module_install_helper'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,7 +29,11 @@ class filebeat::config {
       'runoptions'        => $filebeat::run_options,
       'processors'        => $filebeat::processors,
       'setup'             => $filebeat::setup,
+      'http.enabled'      => $filebeat::http_enabled,
+      'http.port'         => $filebeat::http_port,
+      'http.host'         => $filebeat::beat_name,
     })
+
     # Add the 'xpack' section if supported (version >= 6.1.0)
     if versioncmp($filebeat::package_ensure, '6.1.0') >= 0 {
       $filebeat_config = deep_merge($filebeat_config_temp, {'xpack' => $filebeat::xpack})

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class filebeat (
   Hash    $setup                                                      = {},
   Array   $modules                                                    = [],
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address = undef, # lint:ignore:140chars
-  Stdlib::Absolutepath $filebeat_path                                 = $filebeat::params::filebeat_path,
+  String $filebeat_path                                 = $filebeat::params::filebeat_path,
   Optional[Hash] $xpack                                               = $filebeat::params::xpack,
 ) inherits filebeat::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,8 @@
 # @param prospectors_merge [Boolean] Whether $prospectors should merge all hiera sources, or use simple automatic parameter lookup
 # proxy_address [String] Proxy server to use for downloading files
 # @param xpack [Hash] Configuration items to export internal stats to a monitoring Elasticsearch cluster
+# @param http_enabled [Boolean] Enable/Disable beats metrics through an http api endpoint
+# @param http_port [Integer] Port on which the metrics endpoint listens on
 class filebeat (
   String  $package_ensure                                             = $filebeat::params::package_ensure,
   Boolean $manage_repo                                                = $filebeat::params::manage_repo,
@@ -89,8 +91,10 @@ class filebeat (
   Hash    $setup                                                      = {},
   Array   $modules                                                    = [],
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $proxy_address = undef, # lint:ignore:140chars
-  String $filebeat_path                                 = $filebeat::params::filebeat_path,
+  String $filebeat_path                                               = $filebeat::params::filebeat_path,
   Optional[Hash] $xpack                                               = $filebeat::params::xpack,
+  Boolean $http_enabled                                               = $filebeat::params::http_enabled,
+  Integer $http_port                                                  = $filebeat::params::http_port,
 ) inherits filebeat::params {
 
   include ::stdlib

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,8 @@ class filebeat::params {
   $conf_template         = "${module_name}/pure_hash.yml.erb"
   $disable_config_test   = false
   $xpack                 = undef
+  $http_enabled          = false
+  $http_port             = 5066
 
   # These are irrelevant as long as the template is set based on the major_version parameter
   # if versioncmp('1.9.1', $::rubyversion) > 0 {


### PR DESCRIPTION
This PR enables http api endpoint params in the module. The default is set to `false`. The default configuration for filebeat `http.host` parameter is to listen on localhost which we change to the FQDN of the host.